### PR TITLE
Game Page: Add media query to fix timer display on larger screens and above

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -165,10 +165,8 @@ main {
     background-color: rgba(224, 133, 41, 0.5);
 }
 
-.ques-timer {
-    display: flex;
-    justify-content: space-between;
-    margin-bottom: 1em;
+.ques-timer h3 {
+   padding: 0.4em 0; 
 }
 
 #spellboard {
@@ -337,8 +335,17 @@ footer {
     font-size: 80%;
 }
 
-/* Media Query: Tablets and above (only needed to change audio width, rest works perfect as is */
-@media screen and (min-width: 768px) {
+/* Media Query: L;arge Phone Screens and above */
+@media screen and (min-width: 425px) {
+    
+    /* Game Page*/
+
+    .ques-timer {
+        display: flex;
+        justify-content: space-between;
+        margin-bottom: 1em;
+    }
+
     audio {
         width: 300px;
     }

--- a/testing.md
+++ b/testing.md
@@ -284,6 +284,8 @@ There were lot of new learnings, while building this project and I am very proud
 
 ![Console Errors- Unresolved](assets/readMeFiles/consoleUnresolved.png)
 
+8. Just after I submitted, I was attending Community QnA webinar on assessment criteria and I asked a ques on media queries when we have not used it and its still responsive. This made me discover that my timer was not responsive on 320px screens, it was fluctuating to next line while playing the game. I created a branch on my submitted project and added a media query to fix the display :D .
+
 ## Unresolved Bugs
 
 There are no known unresolved bugs. Please create an issue with full details if you come across one. Thank you for your time to review the game.


### PR DESCRIPTION
The timer display on small screen sizes was causing a flicker in the  display of the questions  because of limited space available. The code in this branch fixes the display of timer on smaller screens and change to flex display on large screens and above. This is also added to testing.md struggles section.